### PR TITLE
Core 1695 delay new

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -357,6 +357,15 @@ template<class T> class RosFilter
                       Eigen::VectorXd &measurement,
                       Eigen::MatrixXd &measurementCovariance);
 
+     //! @brief Publishes the current state vector
+     //! @param[in] stamp - The time stamp to use for the published msg header
+     //!
+     void publishState(const ros::Time stamp);
+
+     //! @brief integrates the measurements in the queue and publishes the result
+     //!
+     void integrationLoop();
+
     //! @brief Vector to hold our acceleration (represented as IMU) message filters so they don't go out of scope.
     //!
     std::map<std::string, imuMFPtr> accelerationMessageFilters_;
@@ -549,8 +558,35 @@ template<class T> class RosFilter
     //! @brief tf frame name that is the parent frame of the transform that this node will calculate and broadcast.
     //!
     std::string worldFrameId_;
-};
 
+    //! @brief Publisher to publish the filtered pose
+    //!
+    ros::Publisher positionPub_;
+
+    //! @brief map to odom transform
+    //!
+    tf2::Transform mapOdomTrans_;
+
+    //! @brief odom to BaseLink transform
+    //!
+    tf2::Transform odomBaseLinkTrans_;
+
+    //! @brief tf message
+    //!
+    geometry_msgs::TransformStamped mapOdomTransMsg_;
+
+    //! @brief tf broadcaster
+    //!
+    tf2_ros::TransformBroadcaster worldTransformBroadcaster_;
+
+    //! @brief mutex for the mesurement queue
+    //!
+    boost::mutex measurementQueueMutex_;
+
+    //! @brief condition variable for the measurement queue
+    //!
+    boost::condition_variable measurementQueueEmpty_;
+  };
 }  // namespace RobotLocalization
 
 #endif  // ROBOT_LOCALIZATION_ROS_FILTER_H

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -360,7 +360,7 @@ template<class T> class RosFilter
      //! @brief Publishes the current state vector
      //! @param[in] stamp - The time stamp to use for the published msg header
      //!
-     void publishState(const ros::Time stamp);
+     void publishState(const ros::Time& stamp);
 
      //! @brief integrates the measurements in the queue and publishes the result
      //!
@@ -561,7 +561,7 @@ template<class T> class RosFilter
 
     //! @brief Publisher to publish the filtered pose
     //!
-    ros::Publisher positionPub_;
+    ros::Publisher odometryPub_;
 
     //! @brief map to odom transform
     //!
@@ -585,7 +585,7 @@ template<class T> class RosFilter
 
     //! @brief condition variable for the measurement queue
     //!
-    boost::condition_variable measurementQueueEmpty_;
+    boost::condition_variable measurementsReady_;
   };
 }  // namespace RobotLocalization
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -181,7 +181,10 @@ namespace RobotLocalization
     meas.updateVector_ = updateVector;
     meas.time_ = time.toSec();
     meas.mahalanobisThresh_ = mahalanobisThresh;
+    boost::mutex::scoped_lock lock(measurementQueueMutex_);
     measurementQueue_.push(meas);
+    measurementQueueEmpty_.notify_all();
+
   }
 
   template<typename T>
@@ -381,23 +384,33 @@ namespace RobotLocalization
   template<typename T>
   void RosFilter<T>::integrateMeasurements(const double currentTime)
   {
+    boost::mutex::scoped_lock lock(measurementQueueMutex_);
+
     RF_DEBUG("------ RosFilter::integrateMeasurements ------\n\n"
              "Integration time is " << std::setprecision(20) << currentTime << "\n"
              << measurementQueue_.size() << " measurements in queue.\n");
 
     // If we have any measurements in the queue, process them
-    if (!measurementQueue_.empty())
+    if(measurementQueueEmpty_.timed_wait(lock,boost::posix_time::milliseconds(filter_.getSensorTimeout()*1000)))
     {
-      while (!measurementQueue_.empty())
+      if(!measurementQueue_.empty())
       {
-        Measurement measurement = measurementQueue_.top();
-        measurementQueue_.pop();
 
-        // This will call predict and, if necessary, correct
-        filter_.processMeasurement(measurement);
+        double lastMessageTime;
+        while (!measurementQueue_.empty())
+        {
+          Measurement measurement = measurementQueue_.top();
+          measurementQueue_.pop();
+          lock.unlock();
+          // This will call predict and, if necessary, correct
+          filter_.processMeasurement(measurement);
+          lastMessageTime = measurement.time_;
+          lock.lock();
+        }
+
+        filter_.setLastUpdateTime(currentTime);
+        publishState(ros::Time(lastMessageTime));
       }
-
-      filter_.setLastUpdateTime(currentTime);
     }
     else if (filter_.getInitializedStatus())
     {
@@ -419,6 +432,7 @@ namespace RobotLocalization
         // Update the last measurement time and last update time
         filter_.setLastMeasurementTime(filter_.getLastMeasurementTime() + lastUpdateDelta);
         filter_.setLastUpdateTime(filter_.getLastUpdateTime() + lastUpdateDelta);
+        publishState(ros::Time(currentTime));
       }
     }
     else
@@ -427,6 +441,119 @@ namespace RobotLocalization
     }
 
     RF_DEBUG("\n----- /RosFilter::integrateMeasurements ------\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::publishState(const ros::Time)
+  {
+      // Get latest state and publish it
+      nav_msgs::Odometry filteredPosition;
+
+      if (getFilteredOdometryMessage(filteredPosition))
+      {
+        worldBaseLinkTransMsg_.transform.translation.x = filteredPosition.pose.pose.position.x;
+        worldBaseLinkTransMsg_.transform.translation.y = filteredPosition.pose.pose.position.y;
+        worldBaseLinkTransMsg_.transform.translation.z = filteredPosition.pose.pose.position.z;
+        worldBaseLinkTransMsg_.transform.rotation = filteredPosition.pose.pose.orientation;
+
+        // If the worldFrameId_ is the odomFrameId_ frame, then we can just send the transform. If the
+        // worldFrameId_ is the mapFrameId_ frame, we'll have some work to do.
+        if(filteredPosition.header.frame_id == odomFrameId_)
+        {
+          worldBaseLinkTransMsg_.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
+          worldBaseLinkTransMsg_.header.frame_id = filteredPosition.header.frame_id;
+          worldBaseLinkTransMsg_.child_frame_id = filteredPosition.child_frame_id;
+          worldTransformBroadcaster_.sendTransform(worldBaseLinkTransMsg_);
+        }
+        else if(filteredPosition.header.frame_id == mapFrameId_)
+        {
+          try
+          {
+            tf2::Transform worldBaseLinkTrans;
+            tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
+
+            tf2::fromMsg(tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, ros::Time(0)).transform,
+                         odomBaseLinkTrans_);
+
+            /*
+             * First, see these two references:
+             * http://wiki.ros.org/tf/Overview/Using%20Published%20Transforms#lookupTransform
+             * http://wiki.ros.org/geometry/CoordinateFrameConventions#Transform_Direction
+             * We have a transform from mapFrameId_->baseLinkFrameId_, but it would actually transform
+             * a given pose from baseLinkFrameId_->mapFrameId_. We then used lookupTransform, whose
+             * first two arguments are target frame and source frame, to get a transform from
+             * baseLinkFrameId_->odomFrameId_. However, this transform would actually transform data
+             * from odomFrameId_->baseLinkFrameId_. Now imagine that we have a position in the
+             * mapFrameId_ frame. First, we multiply it by the inverse of the
+             * mapFrameId_->baseLinkFrameId, which will transform that data from mapFrameId_ to
+             * baseLinkFrameId_. Now we want to go from baseLinkFrameId_->odomFrameId_, but the
+             * transform we have takes data from odomFrameId_->baseLinkFrameId_, so we need its
+             * inverse as well. We have now transformed our data from mapFrameId_ to odomFrameId_.
+             * However, if we want other users to be able to do the same, we need to broadcast
+             * the inverse of that entire transform.
+            */
+
+            mapOdomTrans_.mult(worldBaseLinkTrans, odomBaseLinkTrans_);
+
+            mapOdomTransMsg_.transform = tf2::toMsg(mapOdomTrans_);
+            mapOdomTransMsg_.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
+            mapOdomTransMsg_.header.frame_id = mapFrameId_;
+            mapOdomTransMsg_.child_frame_id = odomFrameId_;
+
+            worldTransformBroadcaster_.sendTransform(mapOdomTransMsg_);
+          }
+          catch(...)
+          {
+            ROS_ERROR_STREAM("Could not obtain transform from " << odomFrameId_ << "->" << baseLinkFrameId_);
+          }
+        }
+        else
+        {
+          ROS_ERROR_STREAM("Odometry message frame_id was " << filteredPosition.header.frame_id <<
+                           ", expected " << mapFrameId_ << " or " << odomFrameId_);
+        }
+
+        // Fire off the position and the transform
+        positionPub_.publish(filteredPosition);
+      }
+  }
+
+  template<typename T>
+  void RosFilter<T>::integrationLoop()
+  {
+    // Not quite sure how to set the limits on the frequency in this case
+    // Set up the frequency diagnostic
+    double minFrequency = frequency_ - 50;
+    double maxFrequency = frequency_ + 50;
+    diagnostic_updater::HeaderlessTopicDiagnostic freqDiag("odometry/filtered",
+                                                           diagnosticUpdater_,
+                                                           diagnostic_updater::FrequencyStatusParam(&minFrequency,
+                                                                                                    &maxFrequency,
+                                                                                                    0.1, 10));
+    ros::Time lastDiagTime = ros::Time::now();
+
+     while (ros::ok())
+     {
+         if(printDiagnostics_)
+         {
+             freqDiag.tick();
+         }
+         // Now we'll integrate any measurements we've received
+         ros::Time curTime = ros::Time::now();
+         integrateMeasurements(ros::Time::now().toSec());
+
+         /* Diagnostics can behave strangely when playing back from bag
+        * files and using simulated time, so we have to check for
+        * time suddenly moving backwards as well as the standard
+        * timeout criterion before publishing. */
+         double diagDuration = (curTime - lastDiagTime).toSec();
+         if(printDiagnostics_ && (diagDuration >= diagnosticUpdater_.getPeriod() || diagDuration < 0.0))
+         {
+             diagnosticUpdater_.force_update();
+             lastDiagTime = curTime;
+         }
+
+     }
   }
 
   template<typename T>
@@ -1506,136 +1633,22 @@ namespace RobotLocalization
       diagnosticUpdater_.add("Filter diagnostic updater", this, &RosFilter<T>::aggregateDiagnostics);
     }
 
-    // Set up the frequency diagnostic
-    double minFrequency = frequency_ - 2;
-    double maxFrequency = frequency_ + 2;
-    diagnostic_updater::HeaderlessTopicDiagnostic freqDiag("odometry/filtered",
-                                                           diagnosticUpdater_,
-                                                           diagnostic_updater::FrequencyStatusParam(&minFrequency,
-                                                                                                    &maxFrequency,
-                                                                                                    0.1, 10));
-
+    
     // We may need to broadcast a different transform than
     // the one we've already calculated.
-    tf2::Transform mapOdomTrans;
-    tf2::Transform odomBaseLinkTrans;
-    geometry_msgs::TransformStamped mapOdomTransMsg;
-    ros::Time curTime;
-    ros::Time lastDiagTime = ros::Time::now();
-
-    // Clear out the transforms
+        // Clear out the transforms
     worldBaseLinkTransMsg_.transform = tf2::toMsg(tf2::Transform::getIdentity());
-    mapOdomTransMsg.transform = tf2::toMsg(tf2::Transform::getIdentity());
+    mapOdomTransMsg_.transform = tf2::toMsg(tf2::Transform::getIdentity());
 
     // Publisher
-    ros::Publisher positionPub = nh_.advertise<nav_msgs::Odometry>("odometry/filtered", 20);
-    tf2_ros::TransformBroadcaster worldTransformBroadcaster;
+    positionPub_ = nh_.advertise<nav_msgs::Odometry>("odometry/filtered", 20);
 
-    ros::Rate loop_rate(frequency_);
+    boost::thread(&RosFilter<T>::integrationLoop, this);
 
     while (ros::ok())
     {
-      // Get latest state and publish it
-      nav_msgs::Odometry filteredPosition;
-
-      if (getFilteredOdometryMessage(filteredPosition))
-      {
-        worldBaseLinkTransMsg_.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
-        worldBaseLinkTransMsg_.header.frame_id = filteredPosition.header.frame_id;
-        worldBaseLinkTransMsg_.child_frame_id = filteredPosition.child_frame_id;
-
-        worldBaseLinkTransMsg_.transform.translation.x = filteredPosition.pose.pose.position.x;
-        worldBaseLinkTransMsg_.transform.translation.y = filteredPosition.pose.pose.position.y;
-        worldBaseLinkTransMsg_.transform.translation.z = filteredPosition.pose.pose.position.z;
-        worldBaseLinkTransMsg_.transform.rotation = filteredPosition.pose.pose.orientation;
-
-        // If the worldFrameId_ is the odomFrameId_ frame, then we can just send the transform. If the
-        // worldFrameId_ is the mapFrameId_ frame, we'll have some work to do.
-        if (filteredPosition.header.frame_id == odomFrameId_)
-        {
-          worldTransformBroadcaster.sendTransform(worldBaseLinkTransMsg_);
-        }
-        else if (filteredPosition.header.frame_id == mapFrameId_)
-        {
-          try
-          {
-            tf2::Transform worldBaseLinkTrans;
-            tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
-
-            tf2::fromMsg(tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, ros::Time(0)).transform,
-                         odomBaseLinkTrans);
-
-            /*
-             * First, see these two references:
-             * http://wiki.ros.org/tf/Overview/Using%20Published%20Transforms#lookupTransform
-             * http://wiki.ros.org/geometry/CoordinateFrameConventions#Transform_Direction
-             * We have a transform from mapFrameId_->baseLinkFrameId_, but it would actually transform
-             * a given pose from baseLinkFrameId_->mapFrameId_. We then used lookupTransform, whose
-             * first two arguments are target frame and source frame, to get a transform from
-             * baseLinkFrameId_->odomFrameId_. However, this transform would actually transform data
-             * from odomFrameId_->baseLinkFrameId_. Now imagine that we have a position in the
-             * mapFrameId_ frame. First, we multiply it by the inverse of the
-             * mapFrameId_->baseLinkFrameId, which will transform that data from mapFrameId_ to
-             * baseLinkFrameId_. Now we want to go from baseLinkFrameId_->odomFrameId_, but the
-             * transform we have takes data from odomFrameId_->baseLinkFrameId_, so we need its
-             * inverse as well. We have now transformed our data from mapFrameId_ to odomFrameId_.
-             * However, if we want other users to be able to do the same, we need to broadcast
-             * the inverse of that entire transform.
-            */
-
-            mapOdomTrans.mult(worldBaseLinkTrans, odomBaseLinkTrans);
-
-            mapOdomTransMsg.transform = tf2::toMsg(mapOdomTrans);
-            mapOdomTransMsg.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
-            mapOdomTransMsg.header.frame_id = mapFrameId_;
-            mapOdomTransMsg.child_frame_id = odomFrameId_;
-
-            worldTransformBroadcaster.sendTransform(mapOdomTransMsg);
-          }
-          catch(...)
-          {
-            ROS_ERROR_STREAM("Could not obtain transform from " << odomFrameId_ << "->" << baseLinkFrameId_);
-          }
-        }
-        else
-        {
-          ROS_ERROR_STREAM("Odometry message frame_id was " << filteredPosition.header.frame_id <<
-                           ", expected " << mapFrameId_ << " or " << odomFrameId_);
-        }
-
-        // Fire off the position and the transform
-        positionPub.publish(filteredPosition);
-
-        if (printDiagnostics_)
-        {
-          freqDiag.tick();
-        }
-      }
-
-      // The spin will call all the available callbacks and enqueue
-      // their received measurements
-      ros::spinOnce();
-
-      // Now we'll integrate any measurements we've received
-      ros::Time curTime = ros::Time::now();
-      integrateMeasurements(ros::Time::now().toSec());
-
-      /* Diagnostics can behave strangely when playing back from bag
-       * files and using simulated time, so we have to check for
-       * time suddenly moving backwards as well as the standard
-       * timeout criterion before publishing. */
-      double diagDuration = (curTime - lastDiagTime).toSec();
-      if (printDiagnostics_ && (diagDuration >= diagnosticUpdater_.getPeriod() || diagDuration < 0.0))
-      {
-        diagnosticUpdater_.force_update();
-        lastDiagTime = curTime;
-      }
-
-      if (!loop_rate.sleep())
-      {
-        ROS_WARN_STREAM("Failed to meet update rate! Try decreasing the rate, limiting "
-                        "sensor output frequency, or limiting the number of sensors.");
-      }
+        //Not sure how to figure out what's the wait duration, currently going with 5ms
+        ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.005));
     }
   }
 
@@ -1653,9 +1666,12 @@ namespace RobotLocalization
 
     // Clear out the measurement queue so that we don't immediately undo our
     // reset.
-    while (!measurementQueue_.empty())
     {
-      measurementQueue_.pop();
+      boost::mutex::scoped_lock lock(measurementQueueMutex_);
+      while(!measurementQueue_.empty())
+      {
+        measurementQueue_.pop();
+      }
     }
 
     // Also set the last set pose time, so we ignore all messages

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -406,10 +406,14 @@ namespace RobotLocalization
           filter_.processMeasurement(measurement);
           lastMessageTime = measurement.time_;
           lock.lock();
+          if (!measurementQueue_.empty())
+            if (measurementQueue_.top().time_ == lastMessageTime)
+              continue;
+          lock.unlock();
+          filter_.setLastUpdateTime(currentTime);
+          publishState(ros::Time(lastMessageTime));
+          lock.lock();
         }
-
-        filter_.setLastUpdateTime(currentTime);
-        publishState(ros::Time(lastMessageTime));
       }
     }
     else if (filter_.getInitializedStatus())


### PR DESCRIPTION
Move the changes of "core_1695_delay" from "master" to "indigo-devel" (incorporating the newest changes from upstream).
Modify the publishing so that it doesn't publish twice for messages that are split into two (ex, don't publish a separate output for each of the pose msg and the twist msg that come from the same odom msg).

@efernandez @servos @ayrton04
