### PR TITLE
Fix a bug with mutex locking

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -412,10 +412,11 @@ namespace RobotLocalization
           filter_.processMeasurement(measurement);
           lastMessageTime = measurement.time_;
           // If the next measurement comes from the same message don't publish
-          if (nextMeasurementTime == lastMessageTime)
-            continue;
-          filter_.setLastUpdateTime(currentTime);
-          publishState(ros::Time(lastMessageTime));
+          if (nextMeasurementTime != lastMessageTime)
+          {
+            filter_.setLastUpdateTime(currentTime);
+            publishState(ros::Time(lastMessageTime));
+          }
           lock.lock();
         }
       }


### PR DESCRIPTION
Lock could be unlocked twice without being locked. Caused a crash.

@efernandez @afakihcpr @ayrton04
