### PR TITLE
Add high covariance volume delta check

### DIFF
--- a/include/robot_localization/filter_utilities.h
+++ b/include/robot_localization/filter_utilities.h
@@ -65,6 +65,25 @@ namespace FilterUtilities
   //!
   void appendPrefix(std::string tfPrefix, std::string &frameId);
 
+  //! @brief Compute covariance volume
+  //!
+  //! Compute the volume of a covariance matrix as its determinant, which is
+  //! computed as the product of the matrix eigenvalues.
+  //!
+  //! If the determinant cannot be computed, the volume returned is +Inf.
+  //!
+  //! @return Volume
+  //!
+  template <typename T, int N>
+  T computeCovarianceVolume(const Eigen::Matrix<T, N, N>& M)
+  {
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<T, N, N> > eigensolver(M);
+
+    return eigensolver.info() == Eigen::Success ?
+           eigensolver.eigenvalues().prod() :
+           std::numeric_limits<T>::infinity();
+  }
+
 }  // namespace FilterUtilities
 }  // namespace RobotLocalization
 

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -277,7 +277,7 @@ template<class T> class RosFilter
     //! why it requires more parameters than just the covariance containers.
     //! @param[in] arr - The source array for the covariance data
     //! @param[in] covariance - The destination matrix for the covariance data
-    //! @param[in] topicName - The name of the source data topic (for debug purposes)
+    //! @param[in] topicName - The name of the source data topic
     //! @param[in] updateVector - The update vector for the source topic
     //! @param[in] offset - The "starting" location within the array/update vector
     //! @param[in] dimension - The number of values to copy, starting at the offset

--- a/test/test_input_covariance.py
+++ b/test/test_input_covariance.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import rospy
+
+from nav_msgs.msg import Odometry
+
+class InputCovarianceTester:
+
+    def __init__(self):
+        self._period = rospy.get_param('~period', 0.05)
+        self._scale = rospy.get_param('~scale', 1e4)
+
+        self._num_msgs = 0
+
+        self._pub = rospy.Publisher('odom', Odometry, queue_size=1)
+
+        self._timer = rospy.Timer(rospy.Duration(self._period), self._publish_odometry)
+
+    def _publish_odometry(self, event):
+        odom = Odometry()
+
+        odom.header.stamp = rospy.get_rostime()
+        odom.header.frame_id = 'odom'
+        odom.child_frame_id = 'base_link'
+
+        odom.pose.pose.orientation.w = 1.0
+
+        odom.pose.covariance[ 0] = self._scale * self._num_msgs
+        odom.pose.covariance[ 7] = 1.0
+        odom.pose.covariance[14] = 1.0
+        odom.pose.covariance[21] = 1.0
+        odom.pose.covariance[28] = 1.0
+        odom.pose.covariance[35] = 1.0
+
+        self._pub.publish(odom)
+
+        self._num_msgs += 1
+
+
+def main():
+    rospy.init_node('test_input_covariance')
+
+    try:
+        InputCovarianceTester()
+        rospy.spin()
+    except KeyboardInterrupt:
+        rospy.signal_shutdown('Ctrl-c received')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This also silence the check for the large covariance check on single covariance elements, which reports harmless warning in some case, e.g. pure wheel (pose) odometry which grows without bounds but it's a normal and intended behaviour.

A script has been added to help testing jumps in the input covariance. With the provided implementation, jumps greater than `1e2` in covariance volume will be reported as diagnostic warnings. Therefore, this doesn't report any warning message:
`test/test_input_covariance.py odom:=/platform_control/odom2 _scale:=10`
but this does:
`test/test_input_covariance.py odom:=/platform_control/odom2 _scale:=1000`
