### PR TITLE
Disable the configuration diagnostic messages when not in debug mode

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1364,7 +1364,7 @@ namespace RobotLocalization
     *    1. Multiple non-differential input sources
     *    2. No absolute *or* velocity measurements for pose variables
     */
-    if (printDiagnostics_)
+    if (printDiagnostics_ && debug) // Only output if in debug mode
     {
       for (int stateVar = StateMemberX; stateVar <= StateMemberYaw; ++stateVar)
       {


### PR DESCRIPTION
@efernandez @afakihcpr 

Silences the configuration warning for having two absolute sources.
