### PR TITLE
CORE-3608 Fix crash

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -564,8 +564,8 @@ namespace RobotLocalization
      {
          // Now we'll integrate any measurements we've received
          ros::Time curTime = ros::Time::now();
-         integrateMeasurements(curTime.now().toSec());
-                 
+         integrateMeasurements(curTime.toSec());
+
          const double diagDuration = (curTime - lastDiagTime).toSec();
          /* Diagnostics can behave strangely when playing back from bag
           * files and using simulated time, so we have to check for


### PR DESCRIPTION
This should help to avoid a crash in `integrateMeasurements`.

I've considered the suggestions from:
- http://www.boost.org/doc/libs/1_58_0/doc/html/thread/synchronization.html#thread.synchronization.condvar_ref.condition_variable.timed_wait_predicate
- https://www.justsoftwaresolutions.co.uk/threading/condition-variable-spurious-wakes.html

I couldn't really reproduce all the crashes we've seen, but now it exists w/o any crash on Ctrl+C.
