### PR TITLE
Set position process noise to zero when robot is not moving

### DIFF
--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -227,6 +227,13 @@ class FilterBase
     //!
     void setSensorTimeout(const double sensorTimeout);
 
+    //! @brief Sets the zero velocity threshold
+    //!
+    //! @param[in] zervoVelocityThreshold - The velocity below which we set process noise to zero
+    //! Note a negative value will disable this feature.
+    //!
+    void setZeroVelocityThreshold(const double zeroVelocityThreshold);
+
     //! @brief Manually sets the filter's state
     //!
     //! @param[in] state - The state to set as the filter's current state
@@ -309,6 +316,10 @@ class FilterBase
     //! this timeout, we will continue to call predict() at the filter's frequency.
     //!
     double sensorTimeout_;
+
+    ///! @brief The threshold on considering a state zero velocity
+    ///!
+    double zeroVelocityThreshold_;
 
     //! @brief This is the robot's state vector, which is what we are trying to
     //! filter. The values in this vector are what get reported by the node.

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -49,7 +49,8 @@ namespace RobotLocalization
     covarianceEpsilon_(STATE_SIZE, STATE_SIZE),
     processNoiseCovariance_(STATE_SIZE, STATE_SIZE),
     identity_(STATE_SIZE, STATE_SIZE),
-    debug_(false)
+    debug_(false),
+    zeroVelocityThreshold_(-1.0)
   {
     initialized_ = false;
 
@@ -254,6 +255,11 @@ namespace RobotLocalization
   void FilterBase::setSensorTimeout(const double sensorTimeout)
   {
     sensorTimeout_ = sensorTimeout;
+  }
+
+  void FilterBase::setZeroVelocityThreshold(const double zeroVelocityThreshold)
+  {
+    zeroVelocityThreshold_ = zeroVelocityThreshold;
   }
 
   void FilterBase::setState(const Eigen::VectorXd &state)

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -686,6 +686,11 @@ namespace RobotLocalization
     nhLocal_.param("sensor_timeout", sensorTimeout, 1.0 / frequency_);
     filter_.setSensorTimeout(sensorTimeout);
 
+    // Get Zero velocity threshold
+    double zeroVelocityThreshold;
+    nhLocal_.param("zero_velocity_threshold", zeroVelocityThreshold, -1.0);
+    filter_.setZeroVelocityThreshold(zeroVelocityThreshold);
+
     // Set the timeToPublish timer
     timeToPublish_.setConditionVariable(measurementsReady_);
     timeToPublish_.setFrequency(frequency_);


### PR DESCRIPTION
Sets the process noise covariance on the positional states to zero when the robot is not moving.

This is a bit of a hack but I can't think of a better way to do it.....

@efernandez  @afakihcpr 
