### PR TITLE
Use main loop directly when disabledAtStartup

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -566,7 +566,7 @@ template<class T> class RosFilter
     //!
     ros::ServiceServer disableSrv_;
 
-    //! @brief Wheter the filter is currently disabled
+    //! @brief Whether the filter is currently disabled or not. See disabledAtStartup_.
     //!
     bool disabled_;
 
@@ -616,9 +616,6 @@ template<class T> class RosFilter
     //! but does not integrate new messages into the state vector.
     //! The filter can be enabled later using a service.
     bool disabledAtStartup_;
-
-    //! @brief Whether the filter is enabled or not. See disabledAtStartup_.
-    bool enabled_;
 
     //! @brief Message that contains our latest transform (i.e., state)
     //!


### PR DESCRIPTION
This **fixes a busy loop** (taking 100%CPU) in the small loop when enabled_ == false on
startup (when disbled_at_startup param is set to true), because there's
no sleep.

By getting rid of enabled_ and using disabled_ attribute only, we can
indeed use the main loop for the case of disabled_at_startup == true,
and still print a ROS_WARN message before the loop.