### PR TITLE
Revert "Disable avx  optimizations"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_localization)
 
-# FIXME(jservos): AVX possibly causing memory corruption in Eigen
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx")
-
 find_package(catkin REQUIRED COMPONENTS
   diagnostic_msgs
   diagnostic_updater


### PR DESCRIPTION
Reverts clearpathrobotics/robot_localization#26

Not sure if now this is an issue, but I think we could try removing it.