### PR TITLE
CORE-10556 Fix access to first measurement

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -532,12 +532,17 @@ namespace RobotLocalization
         RF_DEBUG("Received a measurement that was " << filter_.getLastMeasurementTime() - firstMeasurement->time_ <<
                  " seconds in the past. Reverting filter state and measurement queue...");
 
+        // Copy first measurement time and topic name so we can use them if revertTo fails, because it can change the
+        // measurement queue and invalidate the first measurement reference.
+        const double firstMeasurementTime = firstMeasurement->time_;
+        const std::string firstMeasurementTopicName = firstMeasurement->topicName_;
+
         int originalCount = static_cast<int>(measurementQueue_.size());
-        if (!revertTo(firstMeasurement->time_ - 1e-9))
+        if (!revertTo(firstMeasurementTime - 1e-9))
         {
-          RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurement->time_ << "\n");
+          RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurementTime << "\n");
           ROS_WARN_STREAM_DELAYED_THROTTLE(historyLength_, "Received old measurement for topic " <<
-            firstMeasurement->topicName_ << ", but history interval is insufficiently sized to revert state and "
+            firstMeasurementTopicName << ", but history interval is insufficiently sized to revert state and "
             "measurement queue.");
           restoredMeasurementCount = 0;
         }

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -537,7 +537,7 @@ namespace RobotLocalization
         const double firstMeasurementTime = firstMeasurement->time_;
         const std::string firstMeasurementTopicName = firstMeasurement->topicName_;
 
-        int originalCount = static_cast<int>(measurementQueue_.size());
+        const int originalCount = static_cast<int>(measurementQueue_.size());
         if (!revertTo(firstMeasurementTime - 1e-9))
         {
           RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurementTime << "\n");


### PR DESCRIPTION
Copy `time_` and `topicName_` b/c `revertTo` invalidates `firstMeasurement` reference to the `measurementQueue_`.

Otherwise we get a crash when we access `topicName_` b/c https://github.com/clearpathrobotics/robot_localization/blob/kinetic-devel/src/ros_filter.cpp#L528 takes a reference to the priority queue (that actually wraps a vector) and we access it here https://github.com/clearpathrobotics/robot_localization/blob/kinetic-devel/src/ros_filter.cpp#L540 (where it crashes) after calling `revertTo`, which touches the `measurementQueue_` and invalidates it:
https://github.com/clearpathrobotics/robot_localization/blob/kinetic-devel/src/ros_filter.cpp#L3122