### PR TITLE
Allow to use safe clamp rotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(robot_localization)
 
 find_package(catkin REQUIRED COMPONENTS
+  angles
   diagnostic_msgs
   diagnostic_updater
   eigen_conversions
@@ -66,6 +67,7 @@ catkin_package(
     ros_robot_localization_listener
     ukf
   CATKIN_DEPENDS
+    angles
     cmake_modules
     diagnostic_msgs
     diagnostic_updater
@@ -91,6 +93,12 @@ catkin_package(
 ###########
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
+
+# Options
+option(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION "Use fast clamp rotation" ON)
+if(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION)
+  add_definitions(-DFAST_CLAMP_ROTATION)
+endif(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION)
 
 # Library definitions
 add_library(filter_utilities src/filter_utilities.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ catkin_package(
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
 # Options
-option(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION "Use fast clamp rotation" ON)
+option(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION "Use fast clamp rotation" OFF)
 if(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION)
   add_definitions(-DFAST_CLAMP_ROTATION)
 endif(${PROJECT_NAME}_USE_FAST_CLAMP_ROTATION)

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>cmake_modules</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/src/filter_utilities.cpp
+++ b/src/filter_utilities.cpp
@@ -33,6 +33,10 @@
 #include "robot_localization/filter_utilities.h"
 #include "robot_localization/filter_common.h"
 
+#ifndef FAST_CLAMP_ROTATION
+#include <angles/angles.h>
+#endif
+
 #include <string>
 #include <vector>
 
@@ -128,6 +132,7 @@ namespace FilterUtilities
 
   double clampRotation(double rotation)
   {
+#ifdef FAST_CLAMP_ROTATION
     while (rotation > PI)
     {
       rotation -= TAU;
@@ -139,6 +144,9 @@ namespace FilterUtilities
     }
 
     return rotation;
+#else
+    return angles::normalize_angle(rotation);
+#endif
   }
 
 }  // namespace FilterUtilities


### PR DESCRIPTION
This angle normalization (or clamping) code:

https://github.com/clearpathrobotics/robot_localization/blob/eed36c96132295903edc2a32f4dde4de09660603/src/filter_utilities.cpp#L129-L142

could lead to 100% CPU running an infinite loop if the input angle is far from normalized.

This PR provides an option to use the safer angles normalization from `angles` package:

https://github.com/ros/angles/blob/174518d46bfe3ae7642765ef9dde07745516f8c7/angles/include/angles/angles.h#L68-L87