### PR TITLE
Don't clear globalCallbackQueue on set pose

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -127,9 +127,6 @@ namespace RobotLocalization
 
     // reset filter to uninitialized state
     filter_.reset();
-
-    // clear all waiting callbacks
-    ros::getGlobalCallbackQueue()->clear();
   }
 
   // @todo: Replace with AccelWithCovarianceStamped
@@ -2128,10 +2125,6 @@ namespace RobotLocalization
     filter_.setEstimateErrorCovariance(measurementCovariance);
 
     filter_.setLastMeasurementTime(ros::Time::now().toSec());
-
-    // This method can apparently cancel all callbacks, and may stop the executing of the very callback that we're
-    // currently in. Therefore, nothing of consequence should come after it.
-    ros::getGlobalCallbackQueue()->clear();
 
     RF_DEBUG("\n------ /RosFilter::setPoseCallback ------\n");
   }


### PR DESCRIPTION
fixes CORE-10163

Clearing the callback queue doesn't clear the subscriber queue, leading
to a full queue and no new messages issued into the user callbacks.
See https://github.com/ros/ros_comm/issues/1169

The underlying issue in ros_comm isn't trivial to solve, so it's better
not to clear. After all, all the callbacks already check if the
measurements time stamps are older than the last set pose timestamp, so
they're ignored.