### PR TITLE
Validate state and covariance

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -269,11 +269,13 @@ template<class T> class RosFilter
                        const CallbackData &callbackData,
                        const std::string &targetFrame);
 
-    //! @brief Validates filter outputs for NaNs and Infinite values
-    //! @param[out] message - The standard ROS odometry message to be validated
-    //! @return true if the filter output is valid, false otherwise
+    //! @brief Check if the filter state and covariance are valid.
     //!
-    bool validateFilterOutput(const nav_msgs::Odometry &message);
+    //! That is, the state is finite and the covariance is symmetric and Positive Definite.
+    //
+    //! @return true if the filter state and covariance are valid, false otherwise.
+    //!
+    bool validState();
 
   protected:
     //! @brief Finds the latest filter state before the given timestamp and makes it the current state again.


### PR DESCRIPTION
refs SEN-1169

- [x] Validate state is finite
- [x] Validate covariance is symmetric and Positive Definite (PD)
- [x] Validate filter state directly, instead of output filter message
- [ ] Validate measurements integrated into the filter and state prediction

The last item is not implemented. It'd required significant code changes. We could consider implementing it in another PR.