### PR TITLE
Install library that is linked against.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ install(TARGETS
   ros_filter
   ros_filter_utilities
   ros_robot_localization_listener
+  robot_localization_estimator
   ukf
   ukf_localization_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
The (installed) library `ros_robot_localization_listener` links against `robot_localization_estimator`, since this is dynamic linkage the linked entity needs to be installed as well to ensure no problems occur when we link another library against `ros_robot_localization_listener`. At least, for clang-10 this is necessary. Gcc seems to glance over it.